### PR TITLE
Type `connect` and `connect_async`

### DIFF
--- a/src/oracledb/connection.py
+++ b/src/oracledb/connection.py
@@ -36,24 +36,22 @@
 import collections
 import functools
 import ssl
+from typing import Any, Callable, Type, Union
 
 import oracledb
 
 from . import __name__ as MODULE_NAME
-
-from typing import Any, Callable, Type, Union
-from . import constants, driver_mode, errors
-from . import base_impl, thick_impl, thin_impl
+from . import base_impl, constants, driver_mode, errors, thick_impl, thin_impl
 from . import pool as pool_module
-from .pipeline import Pipeline
+from .aq import MessageProperties, Queue
+from .base_impl import DB_TYPE_BLOB, DB_TYPE_CLOB, DB_TYPE_NCLOB, DbType
 from .connect_params import ConnectParams
 from .cursor import AsyncCursor, Cursor
-from .lob import AsyncLOB, LOB
-from .subscr import Subscription
-from .aq import Queue, MessageProperties
+from .dbobject import DbObject, DbObjectType
+from .lob import LOB, AsyncLOB
+from .pipeline import Pipeline
 from .soda import SodaDatabase
-from .dbobject import DbObjectType, DbObject
-from .base_impl import DB_TYPE_BLOB, DB_TYPE_CLOB, DB_TYPE_NCLOB, DbType
+from .subscr import Subscription
 
 # named tuple used for representing global transactions
 Xid = collections.namedtuple(
@@ -1165,7 +1163,9 @@ class Connection(BaseConnection):
         subscr._impl.unsubscribe(self._impl)
 
 
-def _connection_factory(f):
+def _connection_factory(
+    f: Callable[..., Connection],
+) -> Callable[..., Connection]:
     """
     Decorator which checks the validity of the supplied keyword parameters by
     calling the original function (which does nothing), then creates and
@@ -1923,7 +1923,9 @@ class AsyncConnection(BaseConnection):
         await self._impl.tpc_rollback(xid)
 
 
-def _async_connection_factory(f):
+def _async_connection_factory(
+    f: Callable[..., AsyncConnection],
+) -> Callable[..., AsyncConnection]:
     """
     Decorator which checks the validity of the supplied keyword parameters by
     calling the original function (which does nothing), then creates and


### PR DESCRIPTION
This PR types the decorators `_connection_factory` and `_async_connection_factory`, avoiding the loss of types when using `connect` and `connect_async` by client projects.

Minimal example to verify correctness (Python 3.8):

```py
from typing import TYPE_CHECKING, Any, Dict

import oracledb


def get_connection() -> oracledb.Connection:
    conn_params: Dict[str, Any] = {}
    return oracledb.connect(**conn_params)


def get_async_connection() -> oracledb.AsyncConnection:
    conn_params: Dict[str, Any] = {}
    return oracledb.connect_async(**conn_params)


if TYPE_CHECKING:
    reveal_type(oracledb.connect)
    reveal_type(oracledb.connect_async)
```

Gives as output using `mypy --strict`:

```bash
sample_connection.py:17: note: Revealed type is "def (*Any, **Any) -> oracledb.connection.Connection"
sample_connection.py:18: note: Revealed type is "def (*Any, **Any) -> oracledb.connection.AsyncConnection"
Success: no issues found in 1 source file
```

Closes #438 