### PR TITLE
bug: parse access_token with urlsafe_b64decode

### DIFF
--- a/src/oracledb/impl/base/connect_params.pyx
+++ b/src/oracledb/impl/base/connect_params.pyx
@@ -291,7 +291,7 @@ cdef class ConnectParamsImpl:
         num_pad = len(header_seg) % 4
         if num_pad != 0:
             header_seg += '=' * num_pad
-        header = json.loads(base64.b64decode(header_seg))
+        header = json.loads(base64.urlsafe_b64decode(header_seg))
         return datetime.datetime.utcfromtimestamp(header["exp"])
 
     cdef bint _get_uses_drcp(self):


### PR DESCRIPTION
Hello, 
to solve issue [#548](https://github.com/oracle/python-oracledb/issues/548), I have replaced `base64.b64decode` with the method from the same library `base64.urlsafe_b64decode`. 