### PR TITLE
Restrict setuptools version range in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "setuptools >= 77.0.0",
+    "setuptools >= 77.0.0, < 82",
     "wheel",
     "cython ~= 3.1",
 ]


### PR DESCRIPTION
1. What versions are you using?

cx_Oracle version: 8.3.0

setuptools version: 82.0.0 (latest at the time of installation)

(Additional Python/platform information can be provided if needed.)

2. Describe the problem

When installing cx_Oracle 8.3.0, the installation fails due to a compatibility issue with newer versions of setuptools.

Starting from setuptools v82.0.0, pkg_resources is no longer supported (see:
https://github.com/pypa/setuptools/blob/v82.0.0/NEWS.rst#deprecations-and-removals
).

Because of this removal, the installation process raises the following error:

ModuleNotFoundError: No module named 'pkg_resources'


To resolve this issue, we plan to set an upper bound for the setuptools version (i.e., < 82.0.0) to prevent installation failures.

3. Oracle Client libraries

(Not applicable in this case — the issue occurs during package installation before Oracle Client configuration.)

4. PATH / LD_LIBRARY_PATH

(Not applicable — installation fails before runtime.)

5. Oracle environment variables

(Not applicable — installation fails before runtime.)