### PR TITLE
thin: guard keyword-value pair decode against empty payload bytes

### DIFF
--- a/src/oracledb/impl/thin/messages/base.pyx
+++ b/src/oracledb/impl/thin/messages/base.pyx
@@ -268,12 +268,20 @@ cdef class Message:
             if num_bytes > 0:
                 binary_value = buf.read_bytes()
             buf.read_ub2(&keyword_num)      # keyword num
+            # `text_value` and `binary_value` start as None and are assigned
+            # only when the corresponding length is non-zero. Some servers
+            # send keyword pairs with zero-length payloads (observed on
+            # ALTER PLUGGABLE DATABASE OPEN / CLOSE in 19c — #587), so guard
+            # the decode/use of each value before applying it.
             if keyword_num == TNS_KEYWORD_NUM_CURRENT_SCHEMA:
-                self.conn_impl._current_schema = text_value.decode()
+                if text_value is not None:
+                    self.conn_impl._current_schema = text_value.decode()
             elif keyword_num == TNS_KEYWORD_NUM_EDITION:
-                self.conn_impl._edition = text_value.decode()
+                if text_value is not None:
+                    self.conn_impl._edition = text_value.decode()
             elif keyword_num == TNS_KEYWORD_NUM_TRANSACTION_ID:
-                self._update_sessionless_txn_state(binary_value)
+                if binary_value is not None:
+                    self._update_sessionless_txn_state(binary_value)
 
     cdef int _process_message(self, ReadBuffer buf,
                               uint8_t message_type) except -1:

--- a/src/oracledb/impl/thin/messages/base.pyx
+++ b/src/oracledb/impl/thin/messages/base.pyx
@@ -271,7 +271,7 @@ cdef class Message:
             # `text_value` and `binary_value` start as None and are assigned
             # only when the corresponding length is non-zero. Some servers
             # send keyword pairs with zero-length payloads (observed on
-            # ALTER PLUGGABLE DATABASE OPEN / CLOSE in 19c — #587), so guard
+            # ALTER PLUGGABLE DATABASE OPEN / CLOSE in 19c, #587), so guard
             # the decode/use of each value before applying it.
             if keyword_num == TNS_KEYWORD_NUM_CURRENT_SCHEMA:
                 if text_value is not None:


### PR DESCRIPTION
Fixes #587.

`_process_keyword_value_pairs` left `text_value` and `binary_value` as `None` whenever the server sent a zero-length payload, then unconditionally called `text_value.decode()` for `TNS_KEYWORD_NUM_CURRENT_SCHEMA` and `TNS_KEYWORD_NUM_EDITION`. `ALTER PLUGGABLE DATABASE OPEN/CLOSE` against 19c reproduces the path, the DDL succeeded server-side but the async client crashed in the response parser and left the connection unusable.

Add the obvious nil-guards on each branch (also on the `TNS_KEYWORD_NUM_TRANSACTION_ID` binary path).