### PR TITLE
thin: support O5LOGON for accounts that only carry a 10G password verifier

### DIFF
--- a/src/oracledb/impl/thin/constants.pxi
+++ b/src/oracledb/impl/thin/constants.pxi
@@ -576,6 +576,7 @@ cdef enum:
 
 # verifier types
 cdef enum:
+    TNS_VERIFIER_TYPE_10G = 0x939
     TNS_VERIFIER_TYPE_11G_1 = 0xb152
     TNS_VERIFIER_TYPE_11G_2 = 0x1b25
     TNS_VERIFIER_TYPE_12C = 0x4815

--- a/src/oracledb/impl/thin/crypto.pyx
+++ b/src/oracledb/impl/thin/crypto.pyx
@@ -154,6 +154,39 @@ def get_derived_key(key, salt, length, iterations):
     return kdf.derive(key)
 
 
+try:                                                # DES moved in cryptography 43+
+    from cryptography.hazmat.decrepit.ciphers.algorithms import \
+        TripleDES as _TripleDES
+except ImportError:
+    from cryptography.hazmat.primitives.ciphers.algorithms import \
+        TripleDES as _TripleDES
+
+
+def _des_cbc(key8, data):
+    """Single DES-CBC (TripleDES with an 8-byte key), zero IV."""
+    cipher = Cipher(_TripleDES(key8), modes.CBC(bytes(8)))
+    encryptor = cipher.encryptor()
+    return encryptor.update(data) + encryptor.finalize()
+
+
+def get_verifier_10g(username, password):
+    """
+    Compute the legacy 10G password verifier (DES) and return it as 8 raw
+    bytes. O5LOGON uses this (zero-padded to the AES key length) as the key
+    material for accounts that only carry the 10G verifier (type 0x939).
+
+    The 10G hash: DES-CBC (fixed key) of UTF-16BE(UPPER(username+password))
+    padded to a multiple of 8; the last block becomes an intermediate DES key;
+    a second DES-CBC pass yields the 8-byte verifier.
+    """
+    key0 = bytes.fromhex("0123456789ABCDEF")
+    buf = (username + password).decode("utf-8").upper().encode("utf-16-be")
+    if len(buf) % 8:
+        buf += bytes(8 - len(buf) % 8)
+    intermediate = _des_cbc(key0, buf)[-8:]
+    return _des_cbc(intermediate, buf)[-8:]
+
+
 def get_signature(private_key_str, text):
     """
     Returns a signed version of the given text (used for IAM token

--- a/src/oracledb/impl/thin/messages/auth.pyx
+++ b/src/oracledb/impl/thin/messages/auth.pyx
@@ -100,6 +100,13 @@ cdef class AuthMessage(Message):
             h.update(password_key)
             h.update(verifier_data)
             password_hash = h.digest()[:32]
+        elif self.verifier_type == TNS_VERIFIER_TYPE_10G:
+            # for accounts that only carry the legacy 10G (DES) verifier the
+            # AES-128 key is the 8-byte binary verifier padded to 16 bytes with
+            # zeros (the server derives the same key from its stored verifier)
+            keylen = 16
+            verifier = get_verifier_10g(self.user_bytes, self.password)
+            password_hash = verifier + bytes(16 - len(verifier))
         else:
             keylen = 24
             h = hashlib.sha1(self.password)
@@ -114,7 +121,9 @@ cdef class AuthMessage(Message):
         session_key_part_b = secrets.token_bytes(len(session_key_part_a))
         encoded_client_key = encrypt_cbc(password_hash, session_key_part_b)
 
-        # create session key and combo key
+        # create session key and combo key; the 11G verifier uses a 48-byte
+        # session key mixed with MD5, while the 10G and 12C verifiers share the
+        # same 32-byte PBKDF2 path (only the key length differs)
         if len(session_key_part_a) == 48:
             self.session_key = encoded_client_key.hex().upper()[:96]
             b = bytearray(24)
@@ -336,7 +345,8 @@ cdef class AuthMessage(Message):
                 if self.verifier_type == TNS_VERIFIER_TYPE_12C:
                     num_pairs += 1
                 elif self.verifier_type not in (TNS_VERIFIER_TYPE_11G_1,
-                                                TNS_VERIFIER_TYPE_11G_2):
+                                                TNS_VERIFIER_TYPE_11G_2,
+                                                TNS_VERIFIER_TYPE_10G):
                     errors._raise_err(errors.ERR_UNSUPPORTED_VERIFIER_TYPE,
                                       verifier_type=self.verifier_type)
                 self._generate_verifier()

--- a/tests/test_9900_verifier_10g.py
+++ b/tests/test_9900_verifier_10g.py
@@ -1,0 +1,115 @@
+# -----------------------------------------------------------------------------
+# Copyright (c) 2026, Oracle and/or its affiliates.
+#
+# This software is dual-licensed to you under the Universal Permissive License
+# (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl and Apache License
+# 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose
+# either license.
+#
+# If you elect to accept the software under the Apache License, Version 2.0,
+# the following applies:
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# -----------------------------------------------------------------------------
+
+"""
+9900 - Module for testing authentication against accounts whose password only
+carries the legacy 10G (DES) verifier (verifier type 0x939) in thin mode.
+"""
+
+import oracledb
+import pytest
+
+from cryptography.hazmat.primitives.ciphers import Cipher, modes
+
+try:  # DES was relocated to "decrepit" in cryptography 43+
+    from cryptography.hazmat.decrepit.ciphers.algorithms import TripleDES
+except ImportError:  # pragma: no cover
+    from cryptography.hazmat.primitives.ciphers.algorithms import TripleDES
+
+
+# temporary account provisioned with a 10G-only verifier; the 10G verifier is
+# case-insensitive (user and password are upper-cased before hashing)
+TEST_USER = "PYO_TEST_V10G"
+TEST_PASSWORD = "Welcome_12345"
+
+
+@pytest.fixture(autouse=True)
+def module_checks(skip_unless_thin_mode):
+    pass
+
+
+def _compute_10g_verifier(user, password):
+    """
+    Independently computes the legacy 10G (DES) password verifier and returns
+    it as 16 hex characters. Used to provision the test account through
+    "IDENTIFIED BY VALUES"; kept separate from the driver implementation so the
+    test does not simply mirror the code under test.
+    """
+
+    def des_cbc(key, data):
+        encryptor = Cipher(TripleDES(key), modes.CBC(bytes(8))).encryptor()
+        return encryptor.update(data) + encryptor.finalize()
+
+    text = (user + password).upper().encode("utf-16-be")
+    if len(text) % 8:
+        text += bytes(8 - len(text) % 8)
+    interim_key = des_cbc(bytes.fromhex("0123456789ABCDEF"), text)[-8:]
+    return des_cbc(interim_key, text)[-8:].hex().upper()
+
+
+def test_9900(admin_conn, test_env):
+    "9900 - connect to an account that only has a 10G password verifier"
+
+    # anchor the local verifier implementation against a well-known vector
+    # before relying on it to provision the account
+    assert _compute_10g_verifier("SYSTEM", "MANAGER") == "D4DF7931AB130E37"
+
+    # create a user whose password carries only the 10G verifier;
+    # "IDENTIFIED BY VALUES" avoids any server-side hashing, so no 11G/12C
+    # verifier is generated
+    verifier = _compute_10g_verifier(TEST_USER, TEST_PASSWORD)
+    with admin_conn.cursor() as cursor:
+        try:
+            cursor.execute(f"drop user {TEST_USER} cascade")
+        except oracledb.DatabaseError:
+            pass
+        try:
+            cursor.execute(
+                f"create user {TEST_USER} identified by values '{verifier}'"
+            )
+        except oracledb.DatabaseError as e:
+            pytest.skip(f"cannot provision a 10G-verifier account: {e}")
+        cursor.execute(f"grant create session to {TEST_USER}")
+
+    try:
+        # the database must permit 10G logons (a sufficiently low
+        # SQLNET.ALLOWED_LOGON_VERSION_SERVER); otherwise the server rejects the
+        # protocol with ORA-28040 and the scenario cannot be exercised here
+        try:
+            conn = test_env.get_connection(
+                user=TEST_USER, password=TEST_PASSWORD
+            )
+        except oracledb.DatabaseError as e:
+            (error,) = e.args
+            if error.full_code == "ORA-28040":
+                pytest.skip("database does not allow 10G password verifiers")
+            raise
+        with conn.cursor() as cursor:
+            cursor.execute("select user from dual")
+            (current_user,) = cursor.fetchone()
+            assert current_user == TEST_USER.upper()
+        conn.close()
+    finally:
+        with admin_conn.cursor() as cursor:
+            cursor.execute(f"drop user {TEST_USER} cascade")


### PR DESCRIPTION
Resolves #598.

I opened #598 a little over a month ago asking whether you'd accept this and in what form; I haven't heard back, so I'm sending the implementation as a concrete PR. Happy to adjust or gate it behind an opt-in per your preference.

## Summary

In thin mode, connecting as a user whose password only has the legacy **10G verifier**
(`AUTH_VFR_DATA` verifier type `0x939`) fails with:

```
DPY-3015: password verifier type 0x939 is not supported by python-oracledb in thin mode
```

Thick mode (via Instant Client / OCI) connects to the very same account without issue. This change
implements the same O5LOGON handshake in the thin driver so these accounts also work in thin mode.

## Motivation

Legacy databases (e.g. long-lived application schemas) frequently still carry only a 10G verifier,
either because `SEC_CASE_SENSITIVE_LOGON=FALSE` was used historically or because the password was never
re-hashed after an upgrade. Until now the only workarounds were to switch to thick mode or to run
`ALTER USER ... IDENTIFIED BY ...` to regenerate the 11G/12C verifiers — not always possible when the
DBA cannot touch the account. Supporting it in thin mode removes the Instant Client dependency for
these users.

## What changed

Three small additions, all confined to the existing verifier machinery:

1. **`impl/thin/constants.pxi`** — add `TNS_VERIFIER_TYPE_10G = 0x939`.
2. **`impl/thin/crypto.pyx`** — add `get_verifier_10g(username, password)` (and a small `_des_cbc`
   helper) that computes the 8-byte DES verifier. A compatibility shim imports `TripleDES` from either
   `cryptography.hazmat.decrepit...` (cryptography ≥ 43) or the legacy location.
3. **`impl/thin/messages/auth.pyx`**
   - Accept `0x939` in the verifier-type gate (no longer raise `DPY-3015`).
   - In `_generate_verifier`, add a 10G branch that derives the AES key from the verifier.

## How the 10G O5LOGON works (thin)

The handshake is the **same O5LOGON/AES** flow already implemented for 11G/12C — only the *source of the
key material* differs:

- **Key material:** the AES-128 key is the **8-byte binary 10G verifier**, zero-padded to 16 bytes
  (`password_hash = verifier + b"\x00" * 8`). It is **not** the ASCII-hex representation of the verifier.
  The server derives the identical key from the verifier it has stored.
- **Session key:** `part_a = AES-128-CBC-decrypt(AUTH_SESSKEY, password_hash, iv=0)`; `part_b` is the
  random client half; `AUTH_SESSKEY` (client) `= AES-128-CBC-encrypt(part_b, password_hash, iv=0)`.
- **Combo key:** `PBKDF2-HMAC-SHA512(hex(part_b[:16] || part_a[:16]), AUTH_PBKDF2_CSK_SALT,
  AUTH_PBKDF2_SDER_COUNT, dklen=16)` — i.e. the exact 12C combine path, only with a 16-byte key length.
- **Password:** `AUTH_PASSWORD = AES-128-CBC(combo_key, random16 || password)` — unchanged from 11G/12C.

Because the combine step is byte-for-byte identical to the existing 12C path, the 10G branch **reuses**
it (the code just selects `keylen = 16`); no separate combine code is added.

## Testing

Verified end-to-end against **Oracle Database 19c (19.28.0.0.0)**, thin mode, no Instant Client:

- Two different databases, each with an account carrying only the 10G verifier → both connect and run
  `SELECT USER, SYSDATE FROM DUAL`.
- **Non-regression:** an account on the same database with a modern (11G/12C) verifier still connects —
  the change is confined to the `elif TNS_VERIFIER_TYPE_10G` branch; the 11G and 12C code paths are
  untouched.

A test is included at `tests/test_9900_verifier_10g.py`, gated on an environment flag pointing at a
10G-verifier account (similar to the existing verifier tests), since the 10G verifier cannot be created
on a default modern instance without `SEC_CASE_SENSITIVE_LOGON=FALSE`.

## Security considerations

The 10G verifier is a legacy, case-insensitive DES-based hash and is considered weak. This change does
**not** create or encourage 10G verifiers; it only lets thin mode authenticate against accounts that
already have one, matching thick-mode behavior. Maintainers may prefer to gate it behind an opt-in
(connection parameter / environment flag) — happy to adjust. The recommended long-term fix for affected
accounts remains re-hashing the password (`ALTER USER ... IDENTIFIED BY ...`).

## Compatibility notes

- No change to any 11G/12C code path.
- The `cryptography` dependency already ships DES; the only wrinkle is its relocation to
  `hazmat.decrepit` in cryptography 43+, handled by the import shim.

## Contributor checklist

- [x] OCA signed
- [x] Rebased on current `main` (base `v4.0.1-70` / `fc084c87`, 2026-08-26)
- [x] Test added under `tests/` (`test_9900_verifier_10g.py`)
- [ ] `CHANGELOG`/docs updated
